### PR TITLE
Update badges to SVG format [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AST
 
-[![Build Status](https://travis-ci.org/whitequark/ast.png?branch=master)](https://travis-ci.org/whitequark/ast)
-[![Code Climate](https://codeclimate.com/github/whitequark/ast.png)](https://codeclimate.com/github/whitequark/ast)
-[![Coverage Status](https://coveralls.io/repos/whitequark/ast/badge.png?branch=master)](https://coveralls.io/r/whitequark/ast)
+[![Build Status](https://travis-ci.org/whitequark/ast.svg?branch=master)](https://travis-ci.org/whitequark/ast)
+[![Code Climate](https://codeclimate.com/github/whitequark/ast.svg)](https://codeclimate.com/github/whitequark/ast)
+[![Coverage Status](https://coveralls.io/repos/whitequark/ast/badge.svg?branch=master)](https://coveralls.io/r/whitequark/ast)
 
 AST is a small library for working with immutable abstract syntax trees.
 


### PR DESCRIPTION
This Pull Request updates badges to SVG format. [Preview README.md](https://github.com/JuanitoFatas/ast/blob/59ebe2ee04b62d75607ea0700f2c6fb8e509faa4/README.md).

P.S. Could you please also add some metadata information of this gem in this page https://rubygems.org/gems/ast/edit :pray::

![screenshot 2015-03-12 15 55 19](https://cloud.githubusercontent.com/assets/1000669/6614046/36ec8eb0-c8d0-11e4-923a-05132d42e6d2.png)

Here are some I know:

| URL                   | VALUE                                      |
| --------------------- | ------------------------------------------ |
| **Source Code URL**   | https://github.com/whitequark/ast        |
| **Documentation URL** | http://www.rubydoc.info/gems/ast     |
| **Wiki URL**          | N/A                                       |
| **Mailing List URL**  | N/A                                        |
| **Bug Tracker URL**   | https://github.com/whitequark/ast/issues |

Thank you!