### PR TITLE
`Node#clone` returns self (they're immutable, after all)

### DIFF
--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -104,6 +104,7 @@ module AST
     def dup
       self
     end
+    alias :clone :dup
 
     # Returns a new instance of Node where non-nil arguments replace the
     # corresponding fields of `self`.

--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -80,7 +80,7 @@ module AST
     # By default, each entry in the `properties` hash is assigned to
     # an instance variable in this instance of Node. A subclass should define
     # attribute readers for such variables. The values passed in the hash
-    # are not frozen or whitelisted; such behavior can also be implemented\
+    # are not frozen or whitelisted; such behavior can also be implemented
     # by subclassing Node and overriding this method.
     #
     # @return [nil]

--- a/test/test_ast.rb
+++ b/test/test_ast.rb
@@ -30,6 +30,10 @@ describe AST::Node do
     @node.dup.should.equal? @node
   end
 
+  it 'should return self when cloning' do
+    @node.clone.should.equal? @node
+  end
+
   it 'should return an updated node, but only if needed' do
     @node.updated().should.be.identical_to @node
     @node.updated(:node).should.be.identical_to @node


### PR DESCRIPTION
Since `Node#dup` returns `self`, it makes sense for `Node#clone` to do the same. (In core Ruby, `dup` copies an object's "frozen" and "tainted" status, and `clone` doesn't.)