### PR TITLE
correct Mixin module constant in code example

### DIFF
--- a/lib/ast/processor/mixin.rb
+++ b/lib/ast/processor/mixin.rb
@@ -37,7 +37,7 @@ module AST
     #     require 'ast'
     #
     #     class ArithmeticsProcessor
-    #       include AST::Processor::Module
+    #       include AST::Processor::Mixin
     #       # This method traverses any binary operators such as (add)
     #       # or (multiply).
     #       def process_binary_op(node)


### PR DESCRIPTION
This is a small change to the processor class code example in `ast/processor/mixin.rb`. This small inaccuracy stood out in such a clear and concise library.

Kudos to you for your work on *ast* :tada:.