### PR TITLE
Fix a deprecation warning of simpleCov

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,10 +5,10 @@ require 'simplecov'
 require 'coveralls'
 
 SimpleCov.start do
-  self.formatter = SimpleCov::Formatter::MultiFormatter[
+  self.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-  ]
+  ])
 
   # Exclude the testsuite itself.
   add_filter "/test/"


### PR DESCRIPTION
`SimpleCov::Formatter::MultiFormatter[]` is deprecated.
So, this PR replaces it with `.new`.
See https://github.com/colszowka/simplecov/blob/cb0e62b37b63816d07bdb15f3ee88ceade0947e5/lib/simplecov/formatter/multi_formatter.rb#L27