### PR TITLE
Use `alias` for definition of `AST::Node#to_a`

### DIFF
--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -177,9 +177,7 @@ module AST
     #     p value    # => (integer 1)
     #
     # @return [Array]
-    def to_a
-      children
-    end
+    alias to_a children
 
     # Converts `self` to a pretty-printed s-expression.
     #

--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -42,11 +42,10 @@ module AST
 
     # Returns the children of this node.
     # The returned value is frozen.
-    # This is very useful in order to decompose nodes
-    # concisely. For example:
+    # The to_a alias is useful for decomposing nodes concisely.
+    # For example:
     #
     #     node = s(:gasgn, :$foo, s(:integer, 1))
-    #     s
     #     var_name, value = *node
     #     p var_name # => :$foo
     #     p value    # => (integer 1)

--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -42,8 +42,18 @@ module AST
 
     # Returns the children of this node.
     # The returned value is frozen.
+    # This is very useful in order to decompose nodes
+    # concisely. For example:
+    #
+    #     node = s(:gasgn, :$foo, s(:integer, 1))
+    #     s
+    #     var_name, value = *node
+    #     p var_name # => :$foo
+    #     p value    # => (integer 1)
+    #
     # @return [Array]
     attr_reader :children
+    alias to_a children
 
     # Returns the precomputed hash value for this node
     # @return [Fixnum]
@@ -166,18 +176,6 @@ module AST
     end
 
     alias << append
-
-    # Returns {#children}. This is very useful in order to decompose nodes
-    # concisely. For example:
-    #
-    #     node = s(:gasgn, :$foo, s(:integer, 1))
-    #     s
-    #     var_name, value = *node
-    #     p var_name # => :$foo
-    #     p value    # => (integer 1)
-    #
-    # @return [Array]
-    alias to_a children
 
     # Converts `self` to a pretty-printed s-expression.
     #


### PR DESCRIPTION
By this change, the method will be faster around 33%.

Benchmark
--------

```
$ time ruby -rast -e 'node = AST::Node.new(:foo, [1,2,3,4,5]); 100000000.times{node.to_a}'
```

Result
-----

|     | before | after |
| --- | ------ | ----- |
| 1st | 4.47   | 2.89  |
| 2nd | 4.10   | 3.03  |
| 3rd | 4.56   | 2.75  |
| 4th | 4.57   | 2.84  |
| 5th | 4.15   | 3.13  |
| avg | 4.37   | 2.928 |

Note
-----

The method is small, but it is called many times by applications(e.g.  RuboCop). So, I think this change makes sense.