### PR TITLE
bump rake (to fix a deprecation warning on 2.7)

### DIFF
--- a/ast.gemspec
+++ b/ast.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE.MIT README.YARD.md} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'rake',                '~> 10.0'
+  s.add_development_dependency 'rake',                '~> 12.3'
 
   s.add_development_dependency 'bacon',               '~> 1.2'
   s.add_development_dependency 'bacon-colored_output'


### PR DESCRIPTION
Fixes a deprecation warning on Ruby 2.7.0

```
$ bundle exec rake
/home/user/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-10.5.0/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
...
```

See https://github.com/ruby/rake/issues/308