### PR TITLE
Fixed AST::Node#updated to always return a copy.

### DIFF
--- a/lib/ast/node.rb
+++ b/lib/ast/node.rb
@@ -140,7 +140,9 @@ module AST
           properties.nil?
         self
       else
-        original_dup.send :initialize, new_type, new_children, new_properties
+        copy = original_dup
+        copy.send :initialize, new_type, new_children, new_properties
+        copy
       end
     end
 

--- a/test/test_ast.rb
+++ b/test/test_ast.rb
@@ -7,9 +7,17 @@ describe AST::Node do
     attr_reader :meta
   end
 
+  class SubclassNode < AST::Node
+    def initialize(*)
+      super
+      nil
+    end
+  end
+
   before do
     @node = AST::Node.new(:node, [ 0, 1 ])
     @metanode = MetaNode.new(:node, [ 0, 1 ], :meta => 'value')
+    @subclass_node = SubclassNode.new(:node, [ 0, 1 ])
   end
 
   it 'should have accessors for type and children' do
@@ -53,6 +61,12 @@ describe AST::Node do
 
     updated = @metanode.updated(nil, nil, :meta => 'other_value')
     updated.meta.should.equal 'other_value'
+  end
+
+  it 'returns updated node for subclasses that override constructor' do
+    updated = @subclass_node.updated(nil, [2])
+    updated.type.should.equal :node
+    updated.children.should.equal [2]
   end
 
   it 'should format to_sexp correctly' do


### PR DESCRIPTION
Currently it relies on a call chain #initialize -> #freeze that returns `self`.
However, overriding constructor in a custom subclass and returning something else breaks `updated`.

Included a test case. Without my fix `updated` returns `nil`.