### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AST is a small library for working with immutable abstract syntax trees.
 
 ## Usage
 
-See the documentation at [GitHub](http://whitequark.github.com/ast/frames.html) or [rdoc.info](http://rdoc.info/gems/ast).
+See the documentation at [GitHub](http://whitequark.github.io/ast/frames.html) or [rdoc.info](http://rdoc.info/gems/ast).
 
 ## Contributing
 


### PR DESCRIPTION
Updates the GitHub documentation link to be the correct one.