### PR TITLE
Update CI matrix, remove redundant `context`s from specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.4'
-          - '2.7'
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
-          - jruby-9.2
+          - '3.4'
           - jruby-9.4
         command: ["bundle exec rake spec"]
         include:


### PR DESCRIPTION
This PR:

1. updates CI matrix (old Rubies have removed, 3.4 has been added)
2. updates specs (removed `if` checks for old Rubies, moved locals to examples, changed `extend AST::Sexp` to `include AST::Sexp`, removed redundant `context` wrappers)